### PR TITLE
Preserve original controller URL for reauthentication

### DIFF
--- a/unifi_controller_api/api_client.py
+++ b/unifi_controller_api/api_client.py
@@ -111,6 +111,7 @@ class UnifiController:
             f"Initializing UnifiController with URL: {controller_url}, is_udm_pro: {is_udm_pro}"
         )
         self.controller_url = controller_url
+        self.original_controller_url = controller_url
         self.is_udm_pro = is_udm_pro
         self.session = requests.Session()
         self.verify_ssl = verify_ssl
@@ -156,9 +157,9 @@ class UnifiController:
         self._password = password
 
         if self.is_udm_pro:
-            login_uri = f"{self.controller_url}/api/auth/login"
+            login_uri = f"{self.original_controller_url}/api/auth/login"
             logger.debug(f"Using UDM Pro authentication endpoint: {login_uri}")
-            self.controller_url = f"{self.controller_url}/proxy/network"
+            self.controller_url = f"{self.original_controller_url}/proxy/network"
         else:
             login_uri = f"{self.controller_url}/api/login"
             logger.debug(f"Using legacy authentication endpoint: {login_uri}")


### PR DESCRIPTION
Fix: Preserve original controller URL for reauthentication

- Added `self.original_controller_url` to store the initial controller URL.
- Modified `authenticate()` to use the original URL for login and reauthentication when `is_udm_pro` is True, while keeping the controller URL intact for future API calls.
- This prevents issues with incorrect login URL when re-authenticating on subsequent calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UniFi OS authentication to properly preserve and use the original controller URL for login and network path construction during API operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->