### PR TITLE
Add UCG Fiber (UDMA6A8) to device-models.json

### DIFF
--- a/unifi_controller_api/device-models.json
+++ b/unifi_controller_api/device-models.json
@@ -2167,6 +2167,55 @@
         },
         "adoptability": "standalone"
     },
+    "UDMA6A8": {
+        "name": "UCG Fiber",
+        "names": {
+            "abbreviation": "UCG Fiber",
+            "fullName": "Cloud Gateway Fiber",
+            "sku": "UCG-Fiber"
+        },
+        "type": "udm",
+        "deviceCapabilities": [
+            "GATEWAY",
+            "SWITCH",
+            "NETWORK_APPLICATION",
+            "PROTECT_APPLICATION"
+        ],
+        "knownUnsupportedFeatures": [
+            "SWITCH_CAP_DOT1X",
+            "SWITCH_CAP_PORT_ISOLATION",
+            "SWITCH_CAP_STORM_CONTROL",
+            "SWITCH_CAP_STP",
+            "SWITCH_CAP_LLDP_MED",
+            "SWITCH_CAP_EGRESS_RATE_LIMIT"
+        ],
+        "subtypes": [
+            "ugw",
+            "usw"
+        ],
+        "diagram": [
+            "01 02 03 04 __ 05 06 07"
+        ],
+        "ports": {
+            "eth0": "LAN",
+            "eth1": "LAN",
+            "eth2": "LAN",
+            "eth3": "LAN",
+            "eth4": "WAN",
+            "eth5": "LAN",
+            "eth6": "WAN2"
+        },
+        "networkGroups": {
+            "eth0": "LAN",
+            "eth1": "LAN",
+            "eth2": "LAN",
+            "eth3": "LAN",
+            "eth4": "WAN",
+            "eth5": "LAN",
+            "eth6": "WAN2"
+        },
+        "adoptability": "standalone"
+    },
     "UDMB": {
         "name": "UAP BeaconHD",
         "names": {


### PR DESCRIPTION
## Summary

- Add the UniFi Cloud Gateway Fiber (model code `UDMA6A8`) to `device-models.json`
- Without this entry, integrations display the raw model code instead of "Cloud Gateway Fiber"

## Device Info

- **Product**: UniFi Cloud Gateway Fiber
- **SKU**: UCG-Fiber
- **Type**: `udm` (gateway/switch)
- **Ports**: 4x 2.5GbE RJ45 LAN, 1x 10GbE RJ45 WAN, 2x 10G SFP+ (1 LAN, 1 WAN2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for UCG Fiber Cloud Gateway devices, enabling users to manage and configure this new network gateway device within the controller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->