### PR TITLE
feat: allow per-call GET request timeouts

### DIFF
--- a/tests/test_request_timeout.py
+++ b/tests/test_request_timeout.py
@@ -72,6 +72,17 @@ def test_get_requests_use_configured_request_timeout():
     assert controller.session.get_calls[0][1]["timeout"] == 7.0
 
 
+def test_get_requests_allow_per_call_timeout_override():
+    controller = make_controller(request_timeout=7.0)
+
+    controller.invoke_get_rest_api_call(
+        "https://controller.example/api/self/sites",
+        timeout=2.5,
+    )
+
+    assert controller.session.get_calls[0][1]["timeout"] == 2.5
+
+
 def test_mutating_requests_use_configured_request_timeout_by_default():
     controller = make_controller(request_timeout=3.0)
 

--- a/tests/test_request_timeout.py
+++ b/tests/test_request_timeout.py
@@ -4,10 +4,9 @@ from unifi_controller_api import UnifiController
 
 
 class FakeResponse:
-    status_code = 200
-
-    def __init__(self, payload=None):
+    def __init__(self, payload=None, status_code=200):
         self._payload = payload or {"meta": {"rc": "ok"}}
+        self.status_code = status_code
 
     def json(self):
         return self._payload
@@ -36,12 +35,20 @@ class RecordingSession:
         return FakeResponse()
 
 
-def make_controller(request_timeout: Optional[float] = None):
+class ReauthGetSession(RecordingSession):
+    def get(self, url, **kwargs):
+        self.get_calls.append((url, kwargs))
+        if len(self.get_calls) == 1:
+            return FakeResponse(status_code=401)
+        return FakeResponse({"meta": {"rc": "ok"}, "data": []})
+
+
+def make_controller(request_timeout: Optional[float] = None, session=None):
     controller = UnifiController.__new__(UnifiController)
     controller.controller_url = "https://controller.example"
     controller.original_controller_url = "https://controller.example"
     controller.is_udm_pro = False
-    controller.session = RecordingSession()
+    controller.session = session or RecordingSession()
     controller.verify_ssl = True
     controller.auth_retry_enabled = False
     controller.auth_retry_count = 1
@@ -81,6 +88,22 @@ def test_get_requests_allow_per_call_timeout_override():
     )
 
     assert controller.session.get_calls[0][1]["timeout"] == 2.5
+
+
+def test_retried_get_request_keeps_per_call_timeout_override():
+    session = ReauthGetSession()
+    controller = make_controller(request_timeout=7.0, session=session)
+    controller.auth_retry_enabled = True
+    controller.auth_retry_count = 1
+    controller._username = "admin"
+    controller._password = "secret"
+
+    controller.invoke_get_rest_api_call(
+        "https://controller.example/api/self/sites",
+        timeout=2.5,
+    )
+
+    assert [call[1]["timeout"] for call in session.get_calls] == [2.5, 2.5]
 
 
 def test_mutating_requests_use_configured_request_timeout_by_default():

--- a/unifi_controller_api/api_client.py
+++ b/unifi_controller_api/api_client.py
@@ -373,7 +373,7 @@ class UnifiController:
             logger.error(f"Error decoding JWT payload from TOKEN cookie: {e}")
             return None
 
-    def invoke_get_rest_api_call(self, url, headers=None):
+    def invoke_get_rest_api_call(self, url, headers=None, timeout=None):
         """
         Make a GET request to the UniFi Controller REST API with automatic session renewal.
 
@@ -384,6 +384,8 @@ class UnifiController:
         Args:
             url: The URL to send the GET request to.
             headers: Optional additional headers to include in the request.
+            timeout: Optional timeout in seconds for this request. Overrides
+                the controller-level request_timeout when provided.
 
         Returns:
             The response object on success.
@@ -393,14 +395,17 @@ class UnifiController:
             UnifiAuthenticationError: If re-authentication fails.
         """
         try:
+            request_timeout = (
+                timeout if timeout is not None else getattr(self, 'request_timeout', None)
+            )
             if headers:
                 response = self.session.get(
                     url, headers=headers, verify=self.verify_ssl,
-                    timeout=getattr(self, 'request_timeout', None))
+                    timeout=request_timeout)
             else:
                 response = self.session.get(
                     url, verify=self.verify_ssl,
-                    timeout=getattr(self, 'request_timeout', None))
+                    timeout=request_timeout)
 
             if response.status_code == 401 and self.auth_retry_enabled:
                 if hasattr(self, '_username') and hasattr(self, '_password'):
@@ -421,11 +426,11 @@ class UnifiController:
                             if headers:
                                 response = self.session.get(
                                     url, headers=headers, verify=self.verify_ssl,
-                                    timeout=getattr(self, 'request_timeout', None))
+                                    timeout=request_timeout)
                             else:
                                 response = self.session.get(
                                     url, verify=self.verify_ssl,
-                                    timeout=getattr(self, 'request_timeout', None))
+                                    timeout=request_timeout)
 
                             if response.status_code != 401:
                                 break


### PR DESCRIPTION
## Summary
- Adds a per-call `timeout` override to `invoke_get_rest_api_call(...)`
- Reuses the selected timeout for both the initial GET and any retry after re-authentication
- Covers the override with a regression test

## Test Plan
- `python -m pytest tests/test_request_timeout.py::test_get_requests_allow_per_call_timeout_override -q` — failed before implementation with `TypeError`
- `python -m pytest tests/test_request_timeout.py -q` — pass
- `python -m pytest -q` — pass
- `ruff check .` — pass
- `python -m pip install -e '.[dev,docs]'` — pass
- `pytest -q` — pass
- `python -m build` — pass
- `twine check dist/*` — pass
- `sphinx-build -E -W -b html docs docs/_build/html` — pass
- `git diff --check` — pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API calls now support per-request timeout overrides, enabling you to specify custom timeout values for individual requests without affecting the default configuration.

* **Tests**
  * Added test to verify per-request timeout overrides work correctly across all request scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tnware/unifi-controller-api/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->