### PR TITLE
fix: redact invalid JWT cookie log

### DIFF
--- a/tests/test_csrf_token.py
+++ b/tests/test_csrf_token.py
@@ -1,0 +1,38 @@
+import logging
+
+from unifi_controller_api import UnifiController
+
+
+class FakeCookies:
+    def __init__(self, token):
+        self.token = token
+
+    def list_domains(self):
+        return ["controller.example"]
+
+    def get(self, name, domain=None):
+        if name == "TOKEN" and domain == "controller.example":
+            return self.token
+        return None
+
+
+class FakeSession:
+    def __init__(self, token):
+        self.cookies = FakeCookies(token)
+
+
+def make_controller_with_token(token):
+    controller = UnifiController.__new__(UnifiController)
+    controller.session = FakeSession(token)
+    return controller
+
+
+def test_invalid_jwt_structure_warning_does_not_log_token_value(caplog):
+    token = "secret-invalid-token"
+    controller = make_controller_with_token(token)
+
+    with caplog.at_level(logging.WARNING, logger="unifi_controller_api.api_client"):
+        assert controller._extract_csrf_token() is None
+
+    assert "Invalid JWT structure found in TOKEN cookie" in caplog.text
+    assert token not in caplog.text

--- a/unifi_controller_api/api_client.py
+++ b/unifi_controller_api/api_client.py
@@ -351,8 +351,7 @@ class UnifiController:
 
         parts = unifi_cookie.split('.')
         if len(parts) != 3:
-            logger.warning(
-                f"Invalid JWT structure found in TOKEN cookie: {unifi_cookie}")
+            logger.warning("Invalid JWT structure found in TOKEN cookie.")
             return None
 
         try:


### PR DESCRIPTION
## Summary
- Redacts the raw UniFi OS `TOKEN` cookie value from the invalid-JWT warning path
- Keeps the warning signal so malformed cookies remain diagnosable without leaking token material
- Adds a regression test that captures logs and asserts the invalid token value is absent

## Test Plan
- `python -m pytest tests/test_csrf_token.py::test_invalid_jwt_structure_warning_does_not_log_token_value -q` — failed before implementation because the token value appeared in logs
- `ruff check .` — pass
- `python -m pytest -q` — pass
- `python -m build` — pass
- `twine check dist/*` — pass
- `sphinx-build -E -W -b html docs docs/_build/html` — pass
- `git diff --check` — pass
